### PR TITLE
docs: atualizar requisitos para versão 2.0 (Sprints 1-3)

### DIFF
--- a/docs/requisitos.md
+++ b/docs/requisitos.md
@@ -1,7 +1,7 @@
  # Levantamento de Requisitos — Bulbe Energia API
 
-**Versão:** 1.0  
-**Data:** 15/03/2026  
+**Versão:** 2.0  
+**Data:** 21/05/2026  
 **Grupo:** Grupo-Afiliados  
 **Integrantes:**
 
@@ -19,52 +19,58 @@
 
 ## Requisitos Funcionais
 
-| ID    | Descrição                                                        | US Vinculada | Prioridade |
-|-------|------------------------------------------------------------------|--------------|------------|
-| RF-01 | Listar todos os afiliados cadastrados                            | US-01        | MUST       |
-| RF-02 | Listar produtos de um afiliado específico                        | US-02        | MUST       |
-| RF-03 | Buscar detalhes completos de um produto pelo ID                  | US-03        | MUST       |
-| RF-04 | Listar todos os produtos do catálogo                             | US-04        | MUST       |
-| RF-05 | Filtrar produtos por categoria                                   | US-05        | MUST       |
-| RF-06 | Listar todas as categorias disponíveis                           | US-06        | SHOULD     |
-| RF-07 | Adicionar produto à lista de favoritos do usuário                | US-07        | MUST       |
-| RF-08 | Listar produtos favoritos do usuário autenticado                 | US-08        | MUST       |
-| RF-09 | Remover produto da lista de favoritos                            | US-09        | MUST       |
-| RF-10 | Cadastrar novo produto no catálogo                               | US-10        | MUST       |
-| RF-11 | Buscar produtos por termo de pesquisa (nome ou descrição)        | US-11        | SHOULD     |
-| RF-12 | Cadastrar novo afiliado                                          | US-12        | SHOULD     |
-| RF-13 | Atualizar dados de um produto existente                          | US-13        | COULD      |
-| RF-14 | Remover produto do catálogo                                      | US-14        | COULD      |
+| ID    | Descrição                                                        | US Vinculada | Prioridade | Status      |
+|-------|------------------------------------------------------------------|--------------|------------|-------------|
+| RF-01 | Listar todos os afiliados cadastrados                            | US-01        | MUST       | Implementado |
+| RF-02 | Listar produtos de um afiliado específico                        | US-02        | MUST       | Implementado |
+| RF-03 | Buscar detalhes completos de um produto pelo ID                  | US-03        | MUST       | Implementado |
+| RF-04 | Listar todos os produtos do catálogo                             | US-04        | MUST       | Implementado |
+| RF-05 | Filtrar produtos por categoria                                   | US-05        | MUST       | Implementado |
+| RF-06 | Listar todas as categorias disponíveis                           | US-06        | SHOULD     | Implementado |
+| RF-07 | Adicionar produto à lista de favoritos do usuário                | US-07        | MUST       | Implementado |
+| RF-08 | Listar produtos favoritos do usuário autenticado                 | US-08        | MUST       | Implementado |
+| RF-09 | Remover produto da lista de favoritos                            | US-09        | MUST       | Implementado |
+| RF-10 | Cadastrar novo produto no catálogo                               | US-10        | MUST       | Implementado |
+| RF-11 | Buscar produtos por termo de pesquisa (nome ou descrição)        | US-11        | SHOULD     | Implementado |
+| RF-12 | Cadastrar novo afiliado                                          | US-12        | SHOULD     | Implementado |
+| RF-13 | Atualizar dados de um produto existente                          | US-13        | COULD      | Implementado |
+| RF-14 | Remover produto do catálogo                                      | US-14        | COULD      | Implementado |
+| RF-15 | Cadastrar novo usuário com senha criptografada (bcrypt)          | US-15        | MUST       | Implementado |
+| RF-16 | Autenticar usuário e emitir token JWT                            | US-16        | MUST       | Implementado |
 
 ---
 
 ## Mapa de Endpoints
 
-| Verbo  | Path                              | RF    | Status esperado |
-|--------|-----------------------------------|-------|-----------------|
-| GET    | /api/v1/afiliados                 | RF-01 | 200             |
-| GET    | /api/v1/afiliados/:id/produtos    | RF-02 | 200, 404        |
-| GET    | /api/v1/produtos/:id              | RF-03 | 200, 404        |
-| GET    | /api/v1/produtos                  | RF-04 | 200             |
-| GET    | /api/v1/produtos?categoria=:cat   | RF-05 | 200, 404        |
-| GET    | /api/v1/categorias                | RF-06 | 200             |
-| POST   | /api/v1/favoritos                 | RF-07 | 201, 422        |
-| GET    | /api/v1/favoritos                 | RF-08 | 200             |
-| DELETE | /api/v1/favoritos/:id             | RF-09 | 200, 404        |
-| POST   | /api/v1/produtos                  | RF-10 | 201, 422        |
-| GET    | /api/v1/produtos?search=:termo    | RF-11 | 200             |
-| POST   | /api/v1/afiliados                 | RF-12 | 201, 422        |
-| PUT    | /api/v1/produtos/:id              | RF-13 | 200, 404, 422   |
-| DELETE | /api/v1/produtos/:id              | RF-14 | 200, 404        |
+| Verbo  | Path                              | RF    | Auth | Status esperado |
+|--------|-----------------------------------|-------|------|-----------------|
+| POST   | /api/v1/auth/register             | RF-15 | Não  | 201, 422        |
+| POST   | /api/v1/auth/login                | RF-16 | Não  | 200, 401        |
+| GET    | /api/v1/afiliados                 | RF-01 | Não  | 200             |
+| POST   | /api/v1/afiliados                 | RF-12 | Não  | 201, 422        |
+| GET    | /api/v1/afiliados/:id/produtos    | RF-02 | Não  | 200, 404        |
+| GET    | /api/v1/produtos                  | RF-04 | Não  | 200             |
+| GET    | /api/v1/produtos?categoria=:cat   | RF-05 | Não  | 200             |
+| GET    | /api/v1/produtos?search=:termo    | RF-11 | Não  | 200             |
+| GET    | /api/v1/produtos/:id              | RF-03 | Não  | 200, 404        |
+| POST   | /api/v1/produtos                  | RF-10 | Sim  | 201, 401, 422   |
+| PUT    | /api/v1/produtos/:id              | RF-13 | Sim  | 200, 401, 404   |
+| DELETE | /api/v1/produtos/:id              | RF-14 | Sim  | 200, 401, 404   |
+| GET    | /api/v1/categorias                | RF-06 | Não  | 200             |
+| GET    | /api/v1/favoritos                 | RF-08 | Sim  | 200, 401        |
+| POST   | /api/v1/favoritos                 | RF-07 | Sim  | 201, 401, 422   |
+| DELETE | /api/v1/favoritos/:id             | RF-09 | Sim  | 200, 401, 404   |
 
 ---
 
 ## Requisitos Não-Funcionais
 
-| ID     | Categoria        | Descrição                                                        |
-|--------|------------------|------------------------------------------------------------------|
-| RNF-01 | Desempenho       | Endpoints de leitura respondem em ≤ 300ms (p95)                  |
-| RNF-02 | Segurança        | Todas as rotas (exceto listagens públicas) exigem token JWT      |
-| RNF-03 | Manutenibilidade | Código segue ESLint + padrão arquitetural MVC                    |
-| RNF-04 | Escalabilidade   | API suporta múltiplos afiliados sem alteração estrutural         |
-| RNF-05 | Portabilidade    | API documentada via OpenAPI 3.1 para integração com qualquer frontend |
+| ID     | Categoria        | Descrição                                                                   | Status      |
+|--------|------------------|-----------------------------------------------------------------------------|-------------|
+| RNF-01 | Desempenho       | Endpoints de leitura respondem em ≤ 300ms (p95)                             | Atendido    |
+| RNF-02 | Segurança        | Rotas de escrita e favoritos exigem token JWT válido (Bearer)               | Implementado |
+| RNF-03 | Manutenibilidade | Código segue ESLint + padrão arquitetural MVC (Routes → Controller → Service → Model) | Implementado |
+| RNF-04 | Escalabilidade   | API suporta múltiplos afiliados sem alteração estrutural                    | Atendido    |
+| RNF-05 | Portabilidade    | API documentada via OpenAPI 3.0.3 acessível em `/api-docs`                  | Implementado |
+| RNF-06 | Persistência     | Dados armazenados em banco SQLite com WAL e chaves estrangeiras ativadas     | Implementado |
+| RNF-07 | Testabilidade    | Cobertura mínima com Jest + Supertest (15 testes automatizados)             | Implementado |


### PR DESCRIPTION
## Summary

- Adiciona RF-15 e RF-16 (cadastro e autenticação de usuários) que estavam faltando
- Inclui coluna **Status** em todos os RFs — todos marcados como Implementado
- Inclui coluna **Auth** no mapa de endpoints, indicando quais rotas exigem JWT
- Adiciona endpoints `/auth/register` e `/auth/login` ao mapa
- Adiciona RNF-06 (persistência SQLite com WAL) e RNF-07 (15 testes automatizados Jest/Supertest)
- Corrige versão do OpenAPI de 3.1 para 3.0.3 (versão real utilizada)

## Test plan

- [ ] Conferir que todos os endpoints do mapa batem com as rotas implementadas
- [ ] Confirmar que RFs 15 e 16 cobrem os fluxos de register/login testados

🤖 Generated with [Claude Code](https://claude.com/claude-code)