### PR TITLE
feat: controle de acesso por papel (admin)

### DIFF
--- a/src/middlewares/adminMiddleware.js
+++ b/src/middlewares/adminMiddleware.js
@@ -1,0 +1,10 @@
+function adminMiddleware(req, res, next) {
+  if (!req.user || req.user.papel !== 'admin') {
+    const err = new Error('Acesso negado. Apenas administradores podem realizar esta ação.');
+    err.status = 403;
+    return next(err);
+  }
+  next();
+}
+
+module.exports = adminMiddleware;

--- a/src/routes/afiliados-routes.js
+++ b/src/routes/afiliados-routes.js
@@ -1,5 +1,7 @@
 const express = require('express');
 const afiliadosController = require('../controllers/afiliados-controller');
+const authMiddleware = require('../middlewares/auth');
+const adminMiddleware = require('../middlewares/adminMiddleware');
 
 const router = express.Router();
 
@@ -54,7 +56,7 @@ router.get('/', afiliadosController.listar);
  *             schema:
  *               $ref: '#/components/schemas/Erro'
  */
-router.post('/', afiliadosController.cadastrar);
+router.post('/', authMiddleware, adminMiddleware, afiliadosController.cadastrar);
 
 /**
  * @openapi

--- a/src/routes/produtos-routes.js
+++ b/src/routes/produtos-routes.js
@@ -1,6 +1,7 @@
 const { Router } = require('express');
 const ProdutosController = require('../controllers/produtos-controller');
 const authMiddleware = require('../middlewares/auth');
+const adminMiddleware = require('../middlewares/adminMiddleware');
 
 const router = Router();
 
@@ -41,6 +42,12 @@ const router = Router();
  *           application/json:
  *             schema:
  *               $ref: '#/components/schemas/Erro'
+ *       403:
+ *         description: Acesso negado. Apenas administradores podem cadastrar produtos
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/Erro'
  *       422:
  *         description: Campos obrigatórios ausentes ou inválidos
  *         content:
@@ -48,7 +55,7 @@ const router = Router();
  *             schema:
  *               $ref: '#/components/schemas/Erro'
  */
-router.post('/', authMiddleware, ProdutosController.cadastrar);
+router.post('/', authMiddleware, adminMiddleware, ProdutosController.cadastrar);
 
 /**
  * @openapi
@@ -63,6 +70,12 @@ router.post('/', authMiddleware, ProdutosController.cadastrar);
  *         schema:
  *           type: string
  *         description: Termo para busca por nome ou descrição
+ *       - in: query
+ *         name: categoria
+ *         required: false
+ *         schema:
+ *           type: string
+ *         description: Filtrar produtos por categoria (ex. "Energia Solar")
  *     responses:
  *       200:
  *         description: Lista retornada com sucesso
@@ -155,7 +168,7 @@ router.get('/:id', ProdutosController.buscarPorId);
  *               $ref: '#/components/schemas/Erro'
  */
 
-router.put('/:id', ProdutosController.atualizar);
+router.put('/:id', authMiddleware, adminMiddleware, ProdutosController.atualizar);
 
 /**
  * @openapi
@@ -182,6 +195,6 @@ router.put('/:id', ProdutosController.atualizar);
  *             schema:
  *               $ref: '#/components/schemas/Erro'
  */
-router.delete('/:id', authMiddleware, ProdutosController.remover);
+router.delete('/:id', authMiddleware, adminMiddleware, ProdutosController.remover);
 
 module.exports = router;


### PR DESCRIPTION
## Summary

- Cria `src/middlewares/adminMiddleware.js` — verifica `req.user.papel === 'admin'` e retorna 403 caso contrário
- Aplica a cadeia `authMiddleware → adminMiddleware` nas rotas de escrita:
  - `POST /api/v1/produtos`
  - `PUT /api/v1/produtos/:id`
  - `DELETE /api/v1/produtos/:id`
  - `POST /api/v1/afiliados`
- Adiciona resposta 403 na documentação OpenAPI do POST /produtos

## Comportamento

| Situação | Status |
|---|---|
| Sem token | 401 |
| Token de cliente (`papel: 'cliente'`) | 403 |
| Token de admin (`papel: 'admin'`) | 201/200 |

## Test plan

- [ ] Login como `admin@bulbe.com` / `admin123` → token com `papel: admin`
- [ ] `POST /produtos` com token admin → 201
- [ ] `POST /produtos` com token cliente → 403
- [ ] `POST /produtos` sem token → 401
- [ ] `POST /afiliados` sem token → 401
- [ ] `POST /afiliados` com token cliente → 403
