### PR TITLE
fix: add tags_home to produtos — corrige carrossel da home

### DIFF
--- a/src/db/conexao.js
+++ b/src/db/conexao.js
@@ -38,6 +38,7 @@ db.exec(`
     preco         REAL    NOT NULL,
     imagem        TEXT,
     link_afiliado TEXT,
+    tags_home     TEXT,
     afiliado_id   INTEGER NOT NULL REFERENCES afiliados(id),
     categoria_id  INTEGER REFERENCES categorias(id)
   );
@@ -49,5 +50,12 @@ db.exec(`
     UNIQUE(usuario_id, produto_id)
   );
 `);
+
+// Migration: add tags_home column to existing databases (safe to run multiple times)
+try {
+  db.exec('ALTER TABLE produtos ADD COLUMN tags_home TEXT');
+} catch (_) {
+  // Column already exists — ignore
+}
 
 module.exports = db;

--- a/src/db/seed.js
+++ b/src/db/seed.js
@@ -4,8 +4,22 @@ const bcrypt = require('bcryptjs');
 const produtosJson = require('../data/produtos.json');
 
 const total = db.prepare('SELECT COUNT(*) as n FROM produtos').get();
-if (total.n > 0) {
-  console.log('Seed já executado. Banco possui dados — pulando.');
+const jaSeeded = total.n > 0;
+
+// Se o banco já tem dados mas falta a coluna tags_home, preenche (migration de dados)
+if (jaSeeded) {
+  const updateTagsHome = db.prepare('UPDATE produtos SET tags_home = ? WHERE id = ?');
+  const semTag = db.prepare('SELECT COUNT(*) as n FROM produtos WHERE tags_home IS NULL').get();
+  if (semTag.n > 0) {
+    console.log('Atualizando tags_home nos produtos existentes...');
+    for (const p of produtosJson) {
+      const tag = p.tags_home ? p.tags_home.join(',') : null;
+      updateTagsHome.run(tag, p.id);
+    }
+    console.log(`✅ tags_home atualizado em ${semTag.n} produto(s).`);
+  } else {
+    console.log('Seed já executado e tags_home já preenchido — nada a fazer.');
+  }
   process.exit(0);
 }
 
@@ -30,8 +44,8 @@ for (const c of categorias) insertCategoria.run(c);
 const getAfiliado = db.prepare('SELECT id FROM afiliados WHERE nome = ?');
 const getCategoria = db.prepare('SELECT id FROM categorias WHERE nome = ?');
 const insertProduto = db.prepare(`
-  INSERT INTO produtos (nome, descricao, preco, imagem, link_afiliado, afiliado_id, categoria_id)
-  VALUES (@nome, @descricao, @preco, @imagem, @link_afiliado, @afiliado_id, @categoria_id)
+  INSERT INTO produtos (nome, descricao, preco, imagem, link_afiliado, tags_home, afiliado_id, categoria_id)
+  VALUES (@nome, @descricao, @preco, @imagem, @link_afiliado, @tags_home, @afiliado_id, @categoria_id)
 `);
 
 let produtosInseridos = 0;
@@ -48,6 +62,7 @@ for (const p of produtosJson) {
     preco: p.preco,
     imagem: p.imagem || null,
     link_afiliado: p.linkAfiliado || null,
+    tags_home: p.tags_home ? p.tags_home.join(',') : null,
     afiliado_id: afiliado.id,
     categoria_id: categoria ? categoria.id : null,
   });

--- a/src/models/produtos-model.js
+++ b/src/models/produtos-model.js
@@ -2,6 +2,7 @@ const db = require('../db/conexao');
 
 const SELECT_PRODUTO = `
   SELECT p.id, p.nome, p.descricao, p.preco, p.imagem, p.link_afiliado AS linkAfiliado,
+         p.tags_home,
          a.nome AS loja, a.logo AS lojalogo, c.nome AS categoria
   FROM produtos p
   LEFT JOIN afiliados a ON p.afiliado_id = a.id


### PR DESCRIPTION
## Problema
O carrossel da home page (Principais / Linha Ecológica / Lançamentos) não exibia produtos porque o `script.js` filtra por `p.tags_home`, mas a coluna não existia na tabela `produtos` do SQLite e não era retornada pela API.

## Solução

### `src/db/conexao.js`
- Adiciona coluna `tags_home TEXT` ao `CREATE TABLE IF NOT EXISTS produtos`
- Adiciona migração `ALTER TABLE produtos ADD COLUMN tags_home TEXT` com try/catch — bancos já existentes recebem a coluna automaticamente ao reiniciar o servidor

### `src/db/seed.js`
- Atualiza INSERT para incluir `tags_home` (array do JSON convertido para string com `.join(',')`)
- Backfill automático: se o banco já tem produtos mas `tags_home` é NULL, atualiza todos os registros existentes com os valores do `produtos.json`

### `src/models/produtos-model.js`
- Adiciona `p.tags_home` ao `SELECT_PRODUTO` para que o campo seja retornado pela API

## Distribuição dos dados
| tags_home | Quantidade |
|---|---|
| `Princpal` | 24 produtos |
| `lançamentos` | 9 produtos |
| `eco` | 5 produtos |
| null | 1 produto |

## Teste
1. Reiniciar o backend — migração aplica a coluna automaticamente
2. `GET /api/v1/produtos` → resposta inclui campo `tags_home`
3. Home page mostra produtos nos três carrosseis

🤖 Generated with [Claude Code](https://claude.com/claude-code)