### PR TITLE
feat: Sprint 4 finalização — closes #80 #81 #85 #92 #95

### DIFF
--- a/src/models/produtos-model.js
+++ b/src/models/produtos-model.js
@@ -34,6 +34,11 @@ const ProdutosModel = {
       .all(nomeAfiliado);
   },
 
+  findByAfiliadoId(afiliadoId) {
+    return db.prepare(`${SELECT_PRODUTO} WHERE p.afiliado_id = ? ORDER BY p.id`)
+      .all(Number(afiliadoId));
+  },
+
   create(dados) {
     const { nome, descricao, preco, imagem, linkAfiliado, loja, categoria } = dados;
 

--- a/src/models/produtos-model.js
+++ b/src/models/produtos-model.js
@@ -29,6 +29,12 @@ const ProdutosModel = {
       .all(`%${categoria}%`);
   },
 
+  findBySearchECategoria(termo, categoria) {
+    const like = `%${termo}%`;
+    return db.prepare(`${SELECT_PRODUTO} WHERE (p.nome LIKE ? OR p.descricao LIKE ?) AND c.nome LIKE ? ORDER BY p.id`)
+      .all(like, like, `%${categoria}%`);
+  },
+
   findByAfiliadoNome(nomeAfiliado) {
     return db.prepare(`${SELECT_PRODUTO} WHERE a.nome = ? ORDER BY p.id`)
       .all(nomeAfiliado);

--- a/src/services/afiliados-service.js
+++ b/src/services/afiliados-service.js
@@ -32,7 +32,7 @@ function listarProdutosPorAfiliado(id) {
     throw err;
   }
 
-  return ProdutosModel.findByAfiliadoNome(afiliado.nome);
+  return ProdutosModel.findByAfiliadoId(afiliado.id);
 }
 
 module.exports = { listarTodos, cadastrar, listarProdutosPorAfiliado };

--- a/src/services/produtos-service.js
+++ b/src/services/produtos-service.js
@@ -58,11 +58,20 @@ const ProdutosService = {
       }
     }
 
+    // Verifica existência antes de tentar atualizar — distingue 404 de 422
+    const existente = ProdutosModel.findById(id);
+    if (!existente) {
+      const err = new Error('Produto não encontrado.');
+      err.status = 404;
+      throw err;
+    }
+
     const produto = ProdutosModel.updateById(id, dados);
 
     if (!produto) {
-      const err = new Error('Produto não encontrado.');
-      err.status = 404;
+      // updateById retorna null apenas quando sets.length === 0 (nenhum campo válido)
+      const err = new Error('Nenhum campo reconhecido para atualizar.');
+      err.status = 422;
       throw err;
     }
 

--- a/src/services/produtos-service.js
+++ b/src/services/produtos-service.js
@@ -21,7 +21,8 @@ const ProdutosService = {
   },
 
   listar({ search, categoria } = {}) {
-    if (search) return ProdutosModel.findBySearch(search);
+    if (search && categoria) return ProdutosModel.findBySearchECategoria(search, categoria);
+    if (search)    return ProdutosModel.findBySearch(search);
     if (categoria) return ProdutosModel.findByCategoria(categoria);
     return ProdutosModel.findAll();
   },

--- a/tests/admin-tests.js
+++ b/tests/admin-tests.js
@@ -1,0 +1,121 @@
+// admin-tests.js — Testes de integração para o adminMiddleware (#92)
+
+const request = require('supertest');
+const jwt     = require('jsonwebtoken');
+const app     = require('../src/app');
+
+const SECRET = process.env.JWT_SECRET || 'bulbe_energia_jwt_secret_key_2024';
+
+function tokenAdmin() {
+  return jwt.sign({ sub: 1, nome: 'Admin', papel: 'admin' },    SECRET, { expiresIn: '1h' });
+}
+
+function tokenCliente() {
+  return jwt.sign({ sub: 9997, nome: 'Cliente', papel: 'cliente' }, SECRET, { expiresIn: '1h' });
+}
+
+const produtoValido = {
+  nome: 'Produto Admin Test',
+  preco: 99.90,
+  categoria: 'Eletrônicos',
+  loja: 'Amazon',
+  imagem: 'test.jpg',
+  linkAfiliado: 'https://example.com',
+};
+
+describe('adminMiddleware — controle de acesso por papel', () => {
+
+  // ── POST /produtos ────────────────────────────────────────
+
+  describe('POST /api/v1/produtos', () => {
+    test('sem token retorna 401', async () => {
+      const res = await request(app).post('/api/v1/produtos').send(produtoValido);
+      expect(res.statusCode).toBe(401);
+    });
+
+    test('com token de cliente retorna 403', async () => {
+      const res = await request(app)
+        .post('/api/v1/produtos')
+        .set('Authorization', `Bearer ${tokenCliente()}`)
+        .send(produtoValido);
+      expect(res.statusCode).toBe(403);
+    });
+
+    test('com token de admin retorna 201', async () => {
+      const res = await request(app)
+        .post('/api/v1/produtos')
+        .set('Authorization', `Bearer ${tokenAdmin()}`)
+        .send(produtoValido);
+      expect(res.statusCode).toBe(201);
+      expect(res.body.data).toHaveProperty('nome', produtoValido.nome);
+    });
+  });
+
+  // ── PUT /produtos ─────────────────────────────────────────
+
+  describe('PUT /api/v1/produtos/:id', () => {
+    test('sem token retorna 401', async () => {
+      const res = await request(app).put('/api/v1/produtos/1').send({ preco: 50 });
+      expect(res.statusCode).toBe(401);
+    });
+
+    test('com token de cliente retorna 403', async () => {
+      const res = await request(app)
+        .put('/api/v1/produtos/1')
+        .set('Authorization', `Bearer ${tokenCliente()}`)
+        .send({ preco: 50 });
+      expect(res.statusCode).toBe(403);
+    });
+
+    test('com token de admin retorna 200', async () => {
+      const res = await request(app)
+        .put('/api/v1/produtos/1')
+        .set('Authorization', `Bearer ${tokenAdmin()}`)
+        .send({ preco: 299.90 });
+      expect(res.statusCode).toBe(200);
+    });
+  });
+
+  // ── DELETE /produtos ──────────────────────────────────────
+
+  describe('DELETE /api/v1/produtos/:id', () => {
+    test('sem token retorna 401', async () => {
+      const res = await request(app).delete('/api/v1/produtos/99999');
+      expect(res.statusCode).toBe(401);
+    });
+
+    test('com token de cliente retorna 403', async () => {
+      const res = await request(app)
+        .delete('/api/v1/produtos/99999')
+        .set('Authorization', `Bearer ${tokenCliente()}`);
+      expect(res.statusCode).toBe(403);
+    });
+
+    test('com token de admin e ID inexistente retorna 404', async () => {
+      const res = await request(app)
+        .delete('/api/v1/produtos/99999')
+        .set('Authorization', `Bearer ${tokenAdmin()}`);
+      expect(res.statusCode).toBe(404);
+    });
+  });
+
+  // ── POST /afiliados ───────────────────────────────────────
+
+  describe('POST /api/v1/afiliados', () => {
+    test('sem token retorna 401', async () => {
+      const res = await request(app)
+        .post('/api/v1/afiliados')
+        .send({ nome: 'Teste', slug: 'teste', logo: 'logo.png', site: 'https://teste.com' });
+      expect(res.statusCode).toBe(401);
+    });
+
+    test('com token de cliente retorna 403', async () => {
+      const res = await request(app)
+        .post('/api/v1/afiliados')
+        .set('Authorization', `Bearer ${tokenCliente()}`)
+        .send({ nome: 'Teste', slug: 'teste', logo: 'logo.png', site: 'https://teste.com' });
+      expect(res.statusCode).toBe(403);
+    });
+  });
+
+});

--- a/tests/afiliados.tests.js
+++ b/tests/afiliados.tests.js
@@ -1,11 +1,61 @@
+// afiliados.tests.js — inclui regressão para bug #80 (#95)
+
 const request = require('supertest');
-const app = require('../src/app');
+const app     = require('../src/app');
 
 describe('Afiliados', () => {
-  test('GET /api/v1/afiliados retorna 200 e array', async () => {
+
+  // ── Listagem ──────────────────────────────────────────────
+
+  test('GET /api/v1/afiliados retorna 200 e array dentro de data', async () => {
     const res = await request(app).get('/api/v1/afiliados');
     expect(res.statusCode).toBe(200);
+    expect(res.body).toHaveProperty('data');
+    expect(Array.isArray(res.body.data)).toBe(true);
+    expect(res.body.data.length).toBeGreaterThan(0);
+  });
+
+  test('GET /api/v1/afiliados retorna campos id, nome, slug, logo, site', async () => {
+    const res = await request(app).get('/api/v1/afiliados');
+    const afiliado = res.body.data[0];
+    expect(afiliado).toHaveProperty('id');
+    expect(afiliado).toHaveProperty('nome');
+    expect(afiliado).toHaveProperty('slug');
+  });
+
+  // ── Produtos por afiliado (#95 — regressão para bug #80) ──
+
+  test('GET /api/v1/afiliados/:id/produtos retorna 200 e array de produtos', async () => {
+    const res = await request(app).get('/api/v1/afiliados/1/produtos');
+    expect(res.statusCode).toBe(200);
     expect(Array.isArray(res.body)).toBe(true);
+    expect(res.body.length).toBeGreaterThan(0);
+  });
+
+  test('produtos de afiliado/1 pertencem todos ao afiliado correto', async () => {
+    const res = await request(app).get('/api/v1/afiliados/1/produtos');
+    expect(res.statusCode).toBe(200);
+    // Pega o nome do afiliado 1 para comparar
+    const afiliadoRes = await request(app).get('/api/v1/afiliados');
+    const afiliado1 = afiliadoRes.body.data.find(a => a.id === 1);
+    // Todos os produtos devem ter a loja igual ao nome do afiliado 1
+    for (const produto of res.body) {
+      expect(produto.loja).toBe(afiliado1.nome);
+    }
+  });
+
+  test('produtos de afiliados diferentes nao se misturam', async () => {
+    const res1 = await request(app).get('/api/v1/afiliados/1/produtos');
+    const res2 = await request(app).get('/api/v1/afiliados/2/produtos');
+    expect(res1.statusCode).toBe(200);
+    expect(res2.statusCode).toBe(200);
+
+    const ids1 = res1.body.map(p => p.id);
+    const ids2 = res2.body.map(p => p.id);
+
+    // Nenhum produto deve aparecer nos dois afiliados
+    const intersecao = ids1.filter(id => ids2.includes(id));
+    expect(intersecao).toHaveLength(0);
   });
 
   test('GET /api/v1/afiliados/:id/produtos com ID inexistente retorna 404', async () => {
@@ -14,11 +64,13 @@ describe('Afiliados', () => {
     expect(res.body).toHaveProperty('erro');
   });
 
-  test('POST /api/v1/afiliados sem campos obrigatórios retorna 422', async () => {
+  // ── Cadastro ──────────────────────────────────────────────
+
+  test('POST /api/v1/afiliados sem token retorna 401', async () => {
     const res = await request(app)
       .post('/api/v1/afiliados')
       .send({ nome: 'Teste' });
-    expect(res.statusCode).toBe(422);
-    expect(res.body).toHaveProperty('erro');
+    expect(res.statusCode).toBe(401);
   });
+
 });


### PR DESCRIPTION
## Issues resolvidas

Closes #80, Closes #81, Closes #85, Closes #92, Closes #95

---

## Commits e responsáveis

### Gui-Pacheco — fix #80
`src/models/produtos-model.js` + `src/services/afiliados-service.js`
- Adiciona `findByAfiliadoId(afiliadoId)` com `WHERE p.afiliado_id = ?`
- `listarProdutosPorAfiliado` passa a usar `findByAfiliadoId` em vez de `findByAfiliadoNome`

### Gui-Pacheco — fix #81
`src/services/produtos-service.js`
- Verifica `findById` antes de chamar `updateById`
- Produto não encontrado → **404**
- Nenhum campo reconhecido → **422** (antes ambos davam 404)

### Laragranato17 — fix #85
`src/models/produtos-model.js` + `src/services/produtos-service.js`
- Adiciona `findBySearchECategoria(termo, categoria)` com AND composto
- `listar()` verifica `search && categoria` antes dos filtros individuais

### Laragranato17 — test #92 (`tests/admin-tests.js` criado)
- 9 testes: POST/PUT/DELETE /produtos e POST /afiliados
- Sem token → 401 | Token cliente → 403 | Token admin → 200/201/404

### Gui-Pacheco — test #95 (`tests/afiliados.tests.js` corrigido)
- Corrige 2 falhas pré-existentes (formato `{ data }` e 401 no POST)
- Adiciona regressão para #80: produtos de afiliados não se misturam
- 7/7 testes passando

---

## Resultado

```
Test Suites: 5 passed, 5 total
Tests:       39 passed, 39 total  ✅
```