### PR TITLE
feat: endpoint GET /api/v1/usuarios (somente admin)

### DIFF
--- a/src/controllers/usuarios-controller.js
+++ b/src/controllers/usuarios-controller.js
@@ -1,0 +1,12 @@
+const usuariosService = require('../services/usuarios-service');
+
+function listar(req, res, next) {
+  try {
+    const usuarios = usuariosService.listarTodos();
+    return res.status(200).json({ data: usuarios });
+  } catch (err) {
+    return next(err);
+  }
+}
+
+module.exports = { listar };

--- a/src/models/users-model.js
+++ b/src/models/users-model.js
@@ -8,6 +8,11 @@ function findById(id) {
   return db.prepare('SELECT * FROM usuarios WHERE id = ?').get(id);
 }
 
+// Lista todos os usuários sem expor a senha
+function findAll() {
+  return db.prepare('SELECT id, nome, email, papel FROM usuarios ORDER BY id').all();
+}
+
 function create({ nome, email, senha, papel = 'cliente' }) {
   const result = db.prepare(
     'INSERT INTO usuarios (nome, email, senha, papel) VALUES (?, ?, ?, ?)'
@@ -16,4 +21,4 @@ function create({ nome, email, senha, papel = 'cliente' }) {
   return db.prepare('SELECT * FROM usuarios WHERE id = ?').get(result.lastInsertRowid);
 }
 
-module.exports = { findByEmail, findById, create };
+module.exports = { findByEmail, findById, findAll, create };

--- a/src/routes/index.js
+++ b/src/routes/index.js
@@ -4,6 +4,7 @@ const favoritosRoutes = require('./favoritos-routes');
 const produtosRoutes = require('./produtos-routes');
 const authRoutes = require('./auth-routes');
 const categoriasRoutes = require('./categorias-routes');
+const usuariosRoutes = require('./usuarios-routes');
 
 const router = express.Router();
 
@@ -14,5 +15,6 @@ router.use('/afiliados', afiliadosRoutes);
 router.use('/favoritos', favoritosRoutes);
 router.use('/categorias', categoriasRoutes);
 router.use('/produtos', produtosRoutes);
+router.use('/usuarios', usuariosRoutes);
 
 module.exports = router;

--- a/src/routes/usuarios-routes.js
+++ b/src/routes/usuarios-routes.js
@@ -1,0 +1,60 @@
+const express = require('express');
+const usuariosController = require('../controllers/usuarios-controller');
+const authMiddleware = require('../middlewares/auth');
+const adminMiddleware = require('../middlewares/adminMiddleware');
+
+const router = express.Router();
+
+/**
+ * @openapi
+ * tags:
+ *   name: Usuários
+ *   description: Gerenciamento de usuários (acesso restrito a administradores)
+ */
+
+/**
+ * @openapi
+ * /usuarios:
+ *   get:
+ *     tags: [Usuários]
+ *     summary: Lista todos os usuários cadastrados (somente admin)
+ *     security:
+ *       - bearerAuth: []
+ *     responses:
+ *       200:
+ *         description: Lista retornada com sucesso
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 data:
+ *                   type: array
+ *                   items:
+ *                     type: object
+ *                     properties:
+ *                       id:
+ *                         type: integer
+ *                       nome:
+ *                         type: string
+ *                       email:
+ *                         type: string
+ *                       papel:
+ *                         type: string
+ *                         enum: [admin, cliente]
+ *       401:
+ *         description: Token ausente ou inválido
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/Erro'
+ *       403:
+ *         description: Acesso restrito a administradores
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/Erro'
+ */
+router.get('/', authMiddleware, adminMiddleware, usuariosController.listar);
+
+module.exports = router;

--- a/src/services/usuarios-service.js
+++ b/src/services/usuarios-service.js
@@ -1,0 +1,7 @@
+const usersModel = require('../models/users-model');
+
+function listarTodos() {
+  return usersModel.findAll();
+}
+
+module.exports = { listarTodos };


### PR DESCRIPTION
## Resumo
Implementa o endpoint que faltava para a aba **Usuários** do painel admin (`GET /api/v1/usuarios`).

## O que foi feito
- `findAll()` no `users-model` (SELECT sem a coluna `senha`)
- `usuarios-service`, `usuarios-controller` e `usuarios-routes` seguindo o padrão MVC dos afiliados
- Rota protegida por `authMiddleware` + `adminMiddleware`
- Registrada em `routes/index.js` e documentada no Swagger

## Comportamento
- `401` sem token
- `403` autenticado mas não-admin
- `200` com admin: retorna `{ data: [{id, nome, email, papel}] }`

## Teste manual
Validado localmente: 401 sem token e 200 com token admin retornando a lista de usuários.
