### PR TITLE
docs: alinha documentacao com o projeto + auth de admin no Swagger de afiliados

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 **Backend do sistema de e-commerce de produtos de afiliados**  
 Projeto desenvolvido para a disciplina de Projeto de Desenvolvimento Backend — IBMEC
 
-![Status](https://img.shields.io/badge/status-em%20desenvolvimento-yellow)
+![Status](https://img.shields.io/badge/status-conclu%C3%ADdo-success)
 ![Node.js](https://img.shields.io/badge/Node.js-18%2B-green)
 ![License](https://img.shields.io/badge/license-MIT-blue)
 
@@ -115,29 +115,38 @@ A API ficará disponível em `http://localhost:3000/api/v1`.
 ## 📡 Endpoints da API
 
 > Consulte o arquivo completo em [`docs/requisitos.md`](./docs/requisitos.md).
+> Legenda de autenticação: **—** público · **JWT** requer token · **Admin** requer token de administrador.
 
-| Verbo  | Path                           | Descrição                          |
-|--------|--------------------------------|------------------------------------|
-| GET    | /api/v1/afiliados              | Lista todos os afiliados           |
-| GET    | /api/v1/afiliados/:id/produtos | Lista produtos de um afiliado      |
-| GET    | /api/v1/produtos               | Lista todos os produtos            |
-| GET    | /api/v1/produtos/:id           | Detalhes de um produto             |
-| GET    | /api/v1/produtos?categoria=    | Filtra produtos por categoria      |
-| GET    | /api/v1/produtos?search=       | Busca produtos por termo           |
-| GET    | /api/v1/categorias             | Lista todas as categorias          |
-| POST   | /api/v1/produtos               | Cadastra novo produto              |
-| PUT    | /api/v1/produtos/:id           | Atualiza produto existente         |
-| DELETE | /api/v1/produtos/:id           | Remove produto do catálogo         |
-| GET    | /api/v1/favoritos              | Lista favoritos do usuário         |
-| POST   | /api/v1/favoritos              | Adiciona produto aos favoritos     |
-| DELETE | /api/v1/favoritos/:id          | Remove produto dos favoritos       |
-| POST   | /api/v1/afiliados              | Cadastra novo afiliado             |
+| Verbo  | Path                           | Descrição                          | Auth  |
+|--------|--------------------------------|------------------------------------|-------|
+| GET    | /api/v1/health                 | Verifica se a API está no ar       | —     |
+| POST   | /api/v1/auth/register          | Cadastra novo usuário (senha em hash) | —  |
+| POST   | /api/v1/auth/login             | Autentica e emite token JWT        | —     |
+| GET    | /api/v1/afiliados              | Lista todos os afiliados           | —     |
+| POST   | /api/v1/afiliados              | Cadastra novo afiliado             | Admin |
+| GET    | /api/v1/afiliados/:id/produtos | Lista produtos de um afiliado      | —     |
+| GET    | /api/v1/produtos               | Lista todos os produtos            | —     |
+| GET    | /api/v1/produtos?categoria=    | Filtra produtos por categoria      | —     |
+| GET    | /api/v1/produtos?search=       | Busca produtos por termo           | —     |
+| GET    | /api/v1/produtos/:id           | Detalhes de um produto             | —     |
+| POST   | /api/v1/produtos               | Cadastra novo produto              | Admin |
+| PUT    | /api/v1/produtos/:id           | Atualiza produto existente         | Admin |
+| DELETE | /api/v1/produtos/:id           | Remove produto do catálogo         | Admin |
+| GET    | /api/v1/categorias             | Lista todas as categorias          | —     |
+| GET    | /api/v1/favoritos              | Lista favoritos do usuário         | JWT   |
+| POST   | /api/v1/favoritos              | Adiciona produto aos favoritos     | JWT   |
+| DELETE | /api/v1/favoritos/:id          | Remove produto dos favoritos       | JWT   |
+| GET    | /api/v1/usuarios               | Lista todos os usuários            | Admin |
 
 ---
 
 ## 📚 Documentação OpenAPI
 
-> Arquivo em [`docs/openapi.yaml`](./docs/openapi.yaml) — a ser preenchido progressivamente.
+A API é documentada via **OpenAPI 3.0.3** e exposta de duas formas:
+
+- **Swagger UI interativo** (gerado em runtime via `swagger-jsdoc` a partir das anotações `@openapi` nas rotas): `http://localhost:3000/api-docs`
+- **JSON da especificação:** `http://localhost:3000/api-docs.json`
+- **Arquivo estático:** [`docs/openapi.yaml`](./docs/openapi.yaml)
 
 ---
 
@@ -155,7 +164,8 @@ bulbe-energia-api-afiliados/
 │   ├── middlewares/          # Auth JWT, tratamento de erros
 │   ├── config/               # Configuração de ambiente
 │   ├── db/
-│   │   └── conexão.js        # Conexão SQLite + criação das tabelas
+│   │   ├── conexao.js        # Conexão SQLite + criação das tabelas
+│   │   └── seed.js           # População inicial do banco (idempotente)
 │   ├── app.js                # Instancia o Express e middlewares
 │   └── server.js             # Sobe o servidor HTTP
 ├── bulbe.db                  # Banco SQLite (gerado automaticamente)
@@ -177,8 +187,8 @@ bulbe-energia-api-afiliados/
 | Kickoff | Apresentação dos trabalhos do semestre anterior | ✅ Concluída |
 | Sprint 1 | Setup + Elicitação de Requisitos | ✅ Concluída |
 | Sprint 2 | Modelagem + Arquitetura + CRUD básico | ✅ Concluída |
-| Sprint 3 | Banco de Dados (SQLite) + Autenticação JWT | 🔄 Em andamento |
-| Sprint 4 | Testes + Documentação Final | ⏳ Aguardando |
+| Sprint 3 | Banco de Dados (SQLite) + Autenticação JWT | ✅ Concluída |
+| Sprint 4 | Testes + Documentação Final | ✅ Concluída |
 
 ---
 

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -1,1 +1,682 @@
- 
+openapi: 3.0.3
+info:
+  title: Bulbe Afiliados API
+  version: 1.0.0
+  description: API REST para gerenciamento do programa de afiliados da Bulbe
+    Energia. Permite listar, consultar e cadastrar produtos, afiliados,
+    favoritos e usuários.
+  contact:
+    name: Equipe Bulbe Energia
+    email: seuemail@alunos.ibmec.edu.br
+servers:
+  - url: http://localhost:3000/api/v1
+    description: Servidor de desenvolvimento local
+paths:
+  /afiliados:
+    get:
+      tags:
+        - Afiliados
+      summary: Lista todos os afiliados
+      responses:
+        "200":
+          description: Lista retornada com sucesso
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  data:
+                    type: array
+                    items:
+                      $ref: "#/components/schemas/Afiliado"
+    post:
+      tags:
+        - Afiliados
+      summary: Cadastra um novo afiliado
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/AfiliadoInput"
+      responses:
+        "201":
+          description: Afiliado cadastrado com sucesso
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Afiliado"
+        "422":
+          description: Dados inválidos ou slug já em uso
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Erro"
+  "/afiliados/{id}/produtos":
+    get:
+      tags:
+        - Afiliados
+      summary: Lista os produtos de um afiliado pelo ID
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema:
+            type: integer
+          description: ID do afiliado
+      responses:
+        "200":
+          description: Lista de produtos retornada com sucesso
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/Produto"
+        "404":
+          description: Afiliado não encontrado
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Erro"
+  /auth/register:
+    post:
+      tags:
+        - Auth
+      summary: Registra um novo usuário
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/RegisterInput"
+      responses:
+        "201":
+          description: Usuário registrado com sucesso!
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Usuario"
+        "422":
+          description: Campos obrigatórios ausentes ou email já cadastrado
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Erro"
+  /auth/login:
+    post:
+      tags:
+        - Auth
+      summary: Autentica um usuário e retorna o token JWT
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/LoginInput"
+      responses:
+        "200":
+          description: Login realizado com sucesso!
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/LoginResponse"
+        "401":
+          description: Login ou senha inválidos
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Erro"
+  /categorias:
+    get:
+      tags:
+        - Categorias
+      summary: Lista todas as categorias disponíveis
+      responses:
+        "200":
+          description: Lista retornada com sucesso
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  data:
+                    type: array
+                    items:
+                      $ref: "#/components/schemas/Categoria"
+  /favoritos:
+    get:
+      tags:
+        - Favoritos
+      summary: Lista os favoritos do usuário autenticado
+      security:
+        - bearerAuth: []
+      responses:
+        "200":
+          description: Lista retornada com sucesso
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  data:
+                    type: array
+                    items:
+                      $ref: "#/components/schemas/Favorito"
+        "401":
+          description: Token ausente ou inválido
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Erro"
+    post:
+      tags:
+        - Favoritos
+      summary: Adiciona um produto aos favoritos
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/FavoritoInput"
+      responses:
+        "201":
+          description: Favorito adicionado com sucesso
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  data:
+                    $ref: "#/components/schemas/Favorito"
+        "401":
+          description: Token ausente ou inválido
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Erro"
+  "/favoritos/{id}":
+    delete:
+      tags:
+        - Favoritos
+      summary: Remove um favorito pelo ID
+      security:
+        - bearerAuth: []
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema:
+            type: string
+          description: ID do favorito a ser removido
+      responses:
+        "200":
+          description: Favorito removido com sucesso
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                    example: Favorito removido com sucesso
+                  data:
+                    $ref: "#/components/schemas/Favorito"
+        "401":
+          description: Token ausente ou inválido
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Erro"
+        "404":
+          description: Favorito não encontrado
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Erro"
+  /produtos:
+    post:
+      tags:
+        - Produtos
+      summary: Cadastra um novo produto
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/ProdutoInput"
+      responses:
+        "201":
+          description: Produto cadastrado com sucesso
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  data:
+                    $ref: "#/components/schemas/Produto"
+        "401":
+          description: Token ausente ou inválido
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Erro"
+        "403":
+          description: Acesso negado. Apenas administradores podem cadastrar produtos
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Erro"
+        "422":
+          description: Campos obrigatórios ausentes ou inválidos
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Erro"
+    get:
+      tags:
+        - Produtos
+      summary: Lista todos os produtos
+      parameters:
+        - in: query
+          name: search
+          required: false
+          schema:
+            type: string
+          description: Termo para busca por nome ou descrição
+        - in: query
+          name: categoria
+          required: false
+          schema:
+            type: string
+          description: Filtrar produtos por categoria (ex. "Energia Solar")
+      responses:
+        "200":
+          description: Lista retornada com sucesso
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  data:
+                    type: array
+                    items:
+                      $ref: "#/components/schemas/Produto"
+  "/produtos/{id}":
+    get:
+      tags:
+        - Produtos
+      summary: Busca um produto pelo ID
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema:
+            type: integer
+          description: ID do produto
+      responses:
+        "200":
+          description: Produto encontrado
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  data:
+                    $ref: "#/components/schemas/Produto"
+        "404":
+          description: Produto não encontrado
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Erro"
+    put:
+      tags:
+        - Produtos
+      summary: Atualiza um produto pelo ID
+      security:
+        - bearerAuth: []
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema:
+            type: integer
+          description: ID do produto
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/ProdutoInput"
+      responses:
+        "200":
+          description: Produto atualizado com sucesso
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  data:
+                    $ref: "#/components/schemas/Produto"
+        "404":
+          description: Produto não encontrado
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Erro"
+        "422":
+          description: Dados inválidos
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Erro"
+    delete:
+      tags:
+        - Produtos
+      summary: Remove um produto pelo ID
+      security:
+        - bearerAuth: []
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema:
+            type: integer
+          description: ID do produto
+      responses:
+        "204":
+          description: Produto removido com sucesso
+        "404":
+          description: Produto não encontrado
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Erro"
+  /usuarios:
+    get:
+      tags:
+        - Usuários
+      summary: Lista todos os usuários cadastrados (somente admin)
+      security:
+        - bearerAuth: []
+      responses:
+        "200":
+          description: Lista retornada com sucesso
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  data:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        id:
+                          type: integer
+                        nome:
+                          type: string
+                        email:
+                          type: string
+                        papel:
+                          type: string
+                          enum:
+                            - admin
+                            - cliente
+        "401":
+          description: Token ausente ou inválido
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Erro"
+        "403":
+          description: Acesso restrito a administradores
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Erro"
+components:
+  securitySchemes:
+    bearerAuth:
+      type: http
+      scheme: bearer
+      bearerFormat: JWT
+  schemas:
+    Erro:
+      type: object
+      properties:
+        erro:
+          type: string
+          example: Mensagem de erro
+    RegisterInput:
+      type: object
+      required:
+        - nome
+        - email
+        - senha
+      properties:
+        nome:
+          type: string
+          example: João Silva
+        email:
+          type: string
+          example: joao@email.com
+        senha:
+          type: string
+          example: senha123
+    LoginInput:
+      type: object
+      required:
+        - email
+        - senha
+      properties:
+        email:
+          type: string
+          example: joao@email.com
+        senha:
+          type: string
+          example: senha123
+    Usuario:
+      type: object
+      properties:
+        id:
+          type: integer
+          example: 1
+        nome:
+          type: string
+          example: João Silva
+        email:
+          type: string
+          example: joao@email.com
+        papel:
+          type: string
+          example: user
+    LoginResponse:
+      type: object
+      properties:
+        token:
+          type: string
+          example: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...
+        user:
+          $ref: "#/components/schemas/Usuario"
+    Afiliado:
+      type: object
+      properties:
+        id:
+          type: integer
+          example: 1
+        nome:
+          type: string
+          example: Amazon
+        slug:
+          type: string
+          example: amazon
+        logo:
+          type: string
+          example: icon-amazon.png
+        site:
+          type: string
+          example: https://www.amazon.com.br
+    AfiliadoInput:
+      type: object
+      required:
+        - nome
+        - slug
+        - logo
+        - site
+      properties:
+        nome:
+          type: string
+          example: Shopee
+        slug:
+          type: string
+          example: shopee
+        logo:
+          type: string
+          example: icon-shopee.png
+        site:
+          type: string
+          example: https://shopee.com.br
+    Categoria:
+      type: object
+      properties:
+        nome:
+          type: string
+          example: Energia Solar
+        slug:
+          type: string
+          example: energia-solar
+    Produto:
+      type: object
+      properties:
+        id:
+          type: integer
+          example: 1
+        nome:
+          type: string
+          example: Carregador e Painel Solar 21W ALLPOWERS
+        preco:
+          type: number
+          example: 280.16
+        categoria:
+          type: string
+          example: Energia Solar
+        imagem:
+          type: string
+          example: carregador-painel.jpg
+        linkAfiliado:
+          type: string
+          example: https://www.amazon.com.br/...
+        loja:
+          type: string
+          example: Amazon
+        lojalogo:
+          type: string
+          example: icon-amazon.png
+        descricao:
+          type: string
+          example: Painel solar inteligente altamente eficiente
+        tags_home:
+          type: array
+          items:
+            type: string
+          example:
+            - eco
+        pagina:
+          type: string
+          example: /paginas/produto.html?id=1
+        totalavali:
+          type: integer
+          example: 13
+        totalstar:
+          type: number
+          example: 4.4
+    ProdutoInput:
+      type: object
+      required:
+        - nome
+        - preco
+        - categoria
+        - loja
+      properties:
+        nome:
+          type: string
+          example: Carregador e Painel Solar 21W ALLPOWERS
+        preco:
+          type: number
+          example: 280.16
+        categoria:
+          type: string
+          example: Energia Solar
+        imagem:
+          type: string
+          example: carregador-painel.jpg
+        linkAfiliado:
+          type: string
+          example: https://www.amazon.com.br/...
+        loja:
+          type: string
+          example: Amazon
+        lojalogo:
+          type: string
+          example: icon-amazon.png
+        descricao:
+          type: string
+          example: Painel solar inteligente altamente eficiente
+        tags_home:
+          type: array
+          items:
+            type: string
+          example:
+            - eco
+        pagina:
+          type: string
+          example: /paginas/produto.html?id=1
+        totalavali:
+          type: integer
+          example: 0
+        totalstar:
+          type: number
+          example: 0
+    Favorito:
+      type: object
+      properties:
+        id:
+          type: string
+          example: "1716123456789"
+        usuarioId:
+          type: string
+          example: "1"
+        produtoId:
+          type: integer
+          example: 3
+        criadoEm:
+          type: string
+          format: date-time
+          example: 2025-05-20T14:32:01.000Z
+    FavoritoInput:
+      type: object
+      required:
+        - produtoId
+      properties:
+        produtoId:
+          type: integer
+          example: 3
+tags:
+  - name: Afiliados
+    description: Gerenciamento de afiliados
+  - name: Auth
+    description: Autenticação e registro de usuários
+  - name: Categorias
+    description: Listagem de categorias de produtos
+  - name: Favoritos
+    description: Gerenciamento de favoritos do usuário autenticado
+  - name: Produtos
+    description: Gerenciamento de produtos
+  - name: Usuários
+    description: Gerenciamento de usuários (acesso restrito a administradores)

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -32,7 +32,9 @@ paths:
     post:
       tags:
         - Afiliados
-      summary: Cadastra um novo afiliado
+      summary: Cadastra um novo afiliado (somente admin)
+      security:
+        - bearerAuth: []
       requestBody:
         required: true
         content:
@@ -46,6 +48,18 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/Afiliado"
+        "401":
+          description: Token ausente ou inválido
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Erro"
+        "403":
+          description: Acesso restrito a administradores
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Erro"
         "422":
           description: Dados inválidos ou slug já em uso
           content:

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -377,6 +377,18 @@ paths:
                 properties:
                   data:
                     $ref: "#/components/schemas/Produto"
+        "401":
+          description: Token ausente ou inválido
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Erro"
+        "403":
+          description: Acesso negado. Apenas administradores podem atualizar produtos
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Erro"
         "404":
           description: Produto não encontrado
           content:
@@ -405,6 +417,18 @@ paths:
       responses:
         "204":
           description: Produto removido com sucesso
+        "401":
+          description: Token ausente ou inválido
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Erro"
+        "403":
+          description: Acesso negado. Apenas administradores podem remover produtos
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Erro"
         "404":
           description: Produto não encontrado
           content:
@@ -509,7 +533,10 @@ components:
           example: joao@email.com
         papel:
           type: string
-          example: user
+          enum:
+            - admin
+            - cliente
+          example: cliente
     LoginResponse:
       type: object
       properties:

--- a/docs/requisitos.md
+++ b/docs/requisitos.md
@@ -37,29 +37,34 @@
 | RF-14 | Remover produto do catálogo                                      | US-14        | COULD      | Implementado |
 | RF-15 | Cadastrar novo usuário com senha criptografada (bcrypt)          | US-15        | MUST       | Implementado |
 | RF-16 | Autenticar usuário e emitir token JWT                            | US-16        | MUST       | Implementado |
+| RF-17 | Listar todos os usuários cadastrados (acesso restrito a admin)   | US-17        | SHOULD     | Implementado |
 
 ---
 
 ## Mapa de Endpoints
 
-| Verbo  | Path                              | RF    | Auth | Status esperado |
-|--------|-----------------------------------|-------|------|-----------------|
-| POST   | /api/v1/auth/register             | RF-15 | Não  | 201, 422        |
-| POST   | /api/v1/auth/login                | RF-16 | Não  | 200, 401        |
-| GET    | /api/v1/afiliados                 | RF-01 | Não  | 200             |
-| POST   | /api/v1/afiliados                 | RF-12 | Não  | 201, 422        |
-| GET    | /api/v1/afiliados/:id/produtos    | RF-02 | Não  | 200, 404        |
-| GET    | /api/v1/produtos                  | RF-04 | Não  | 200             |
-| GET    | /api/v1/produtos?categoria=:cat   | RF-05 | Não  | 200             |
-| GET    | /api/v1/produtos?search=:termo    | RF-11 | Não  | 200             |
-| GET    | /api/v1/produtos/:id              | RF-03 | Não  | 200, 404        |
-| POST   | /api/v1/produtos                  | RF-10 | Sim  | 201, 401, 422   |
-| PUT    | /api/v1/produtos/:id              | RF-13 | Sim  | 200, 401, 404   |
-| DELETE | /api/v1/produtos/:id              | RF-14 | Sim  | 200, 401, 404   |
-| GET    | /api/v1/categorias                | RF-06 | Não  | 200             |
-| GET    | /api/v1/favoritos                 | RF-08 | Sim  | 200, 401        |
-| POST   | /api/v1/favoritos                 | RF-07 | Sim  | 201, 401, 422   |
-| DELETE | /api/v1/favoritos/:id             | RF-09 | Sim  | 200, 401, 404   |
+> **Auth:** _Não_ = público · _JWT_ = requer token válido · _Admin_ = requer token de administrador.
+
+| Verbo  | Path                              | RF    | Auth  | Status esperado |
+|--------|-----------------------------------|-------|-------|-----------------|
+| GET    | /api/v1/health                    | —     | Não   | 200             |
+| POST   | /api/v1/auth/register             | RF-15 | Não   | 201, 422        |
+| POST   | /api/v1/auth/login                | RF-16 | Não   | 200, 401        |
+| GET    | /api/v1/afiliados                 | RF-01 | Não   | 200             |
+| POST   | /api/v1/afiliados                 | RF-12 | Admin | 201, 401, 403, 422 |
+| GET    | /api/v1/afiliados/:id/produtos    | RF-02 | Não   | 200, 404        |
+| GET    | /api/v1/produtos                  | RF-04 | Não   | 200             |
+| GET    | /api/v1/produtos?categoria=:cat   | RF-05 | Não   | 200             |
+| GET    | /api/v1/produtos?search=:termo    | RF-11 | Não   | 200             |
+| GET    | /api/v1/produtos/:id              | RF-03 | Não   | 200, 404        |
+| POST   | /api/v1/produtos                  | RF-10 | Admin | 201, 401, 403, 422 |
+| PUT    | /api/v1/produtos/:id              | RF-13 | Admin | 200, 401, 403, 404 |
+| DELETE | /api/v1/produtos/:id              | RF-14 | Admin | 200, 401, 403, 404 |
+| GET    | /api/v1/categorias                | RF-06 | Não   | 200             |
+| GET    | /api/v1/favoritos                 | RF-08 | JWT   | 200, 401        |
+| POST   | /api/v1/favoritos                 | RF-07 | JWT   | 201, 401, 422   |
+| DELETE | /api/v1/favoritos/:id             | RF-09 | JWT   | 200, 401, 404   |
+| GET    | /api/v1/usuarios                  | RF-17 | Admin | 200, 401, 403   |
 
 ---
 
@@ -68,9 +73,9 @@
 | ID     | Categoria        | Descrição                                                                   | Status      |
 |--------|------------------|-----------------------------------------------------------------------------|-------------|
 | RNF-01 | Desempenho       | Endpoints de leitura respondem em ≤ 300ms (p95)                             | Atendido    |
-| RNF-02 | Segurança        | Rotas de escrita e favoritos exigem token JWT válido (Bearer)               | Implementado |
+| RNF-02 | Segurança        | Rotas de escrita exigem token de admin; favoritos exigem token JWT válido (Bearer) | Implementado |
 | RNF-03 | Manutenibilidade | Código segue ESLint + padrão arquitetural MVC (Routes → Controller → Service → Model) | Implementado |
 | RNF-04 | Escalabilidade   | API suporta múltiplos afiliados sem alteração estrutural                    | Atendido    |
 | RNF-05 | Portabilidade    | API documentada via OpenAPI 3.0.3 acessível em `/api-docs`                  | Implementado |
 | RNF-06 | Persistência     | Dados armazenados em banco SQLite com WAL e chaves estrangeiras ativadas     | Implementado |
-| RNF-07 | Testabilidade    | Cobertura mínima com Jest + Supertest (15 testes automatizados)             | Implementado |
+| RNF-07 | Testabilidade    | Cobertura com Jest + Supertest (54 casos em 6 suítes: auth, afiliados, produtos, categorias, favoritos, admin) | Implementado |

--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
   "scripts": {
     "test": "jest --forceExit",
     "start": "node src/server.js",
-    "dev": "nodemon src/server.js"
+    "dev": "nodemon src/server.js",
+    "docs": "node scripts/gerar-openapi.js"
   },
   "repository": {
     "type": "git",
@@ -40,6 +41,7 @@
   "devDependencies": {
     "jest": "^30.4.2",
     "nodemon": "^3.1.14",
-    "supertest": "^7.2.2"
+    "supertest": "^7.2.2",
+    "yaml": "^2.0.0"
   }
 }

--- a/scripts/gerar-openapi.js
+++ b/scripts/gerar-openapi.js
@@ -1,0 +1,32 @@
+// Gera docs/openapi.yaml a partir das anotações @openapi nas rotas.
+// Mantém o arquivo estático sempre fiel ao código. Rode: node scripts/gerar-openapi.js
+const fs = require('node:fs');
+const { join } = require('node:path');
+const swaggerJsdoc = require('swagger-jsdoc');
+const YAML = require('yaml');
+
+const ROOT = join(__dirname, '..');
+
+const options = {
+  definition: {
+    openapi: '3.0.3',
+    info: {
+      title: 'Bulbe Afiliados API',
+      version: '1.0.0',
+      description:
+        'API REST para gerenciamento do programa de afiliados da Bulbe Energia. ' +
+        'Permite listar, consultar e cadastrar produtos, afiliados, favoritos e usuários.',
+      contact: { name: 'Equipe Bulbe Energia', email: 'seuemail@alunos.ibmec.edu.br' },
+    },
+    servers: [
+      { url: 'http://localhost:3000/api/v1', description: 'Servidor de desenvolvimento local' },
+    ],
+  },
+  apis: [join(ROOT, 'src', 'routes', '*.js')],
+};
+
+const doc = swaggerJsdoc(options);
+const yaml = YAML.stringify(doc);
+const out = join(ROOT, 'docs', 'openapi.yaml');
+fs.writeFileSync(out, yaml, 'utf8');
+console.log(`openapi.yaml gerado com ${Object.keys(doc.paths || {}).length} paths em ${out}`);

--- a/src/routes/afiliados-routes.js
+++ b/src/routes/afiliados-routes.js
@@ -38,7 +38,9 @@ router.get('/', afiliadosController.listar);
  * /afiliados:
  *   post:
  *     tags: [Afiliados]
- *     summary: Cadastra um novo afiliado
+ *     summary: Cadastra um novo afiliado (somente admin)
+ *     security:
+ *       - bearerAuth: []
  *     requestBody:
  *       required: true
  *       content:
@@ -52,6 +54,18 @@ router.get('/', afiliadosController.listar);
  *           application/json:
  *             schema:
  *               $ref: '#/components/schemas/Afiliado'
+ *       401:
+ *         description: Token ausente ou inválido
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/Erro'
+ *       403:
+ *         description: Acesso restrito a administradores
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/Erro'
  *       422:
  *         description: Dados inválidos ou slug já em uso
  *         content:

--- a/src/routes/produtos-routes.js
+++ b/src/routes/produtos-routes.js
@@ -154,6 +154,18 @@ router.get('/:id', ProdutosController.buscarPorId);
  *               properties:
  *                 data:
  *                   $ref: '#/components/schemas/Produto'
+ *       401:
+ *         description: Token ausente ou inválido
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/Erro'
+ *       403:
+ *         description: Acesso negado. Apenas administradores podem atualizar produtos
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/Erro'
  *       404:
  *         description: Produto não encontrado
  *         content:
@@ -188,6 +200,18 @@ router.put('/:id', authMiddleware, adminMiddleware, ProdutosController.atualizar
  *     responses:
  *       204:
  *         description: Produto removido com sucesso
+ *       401:
+ *         description: Token ausente ou inválido
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/Erro'
+ *       403:
+ *         description: Acesso negado. Apenas administradores podem remover produtos
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/Erro'
  *       404:
  *         description: Produto não encontrado
  *         content:

--- a/src/routes/schemas.js
+++ b/src/routes/schemas.js
@@ -55,7 +55,8 @@
  *           example: joao@email.com
  *         papel:
  *           type: string
- *           example: user
+ *           enum: [admin, cliente]
+ *           example: cliente
  *
  *     LoginResponse:
  *       type: object


### PR DESCRIPTION
## Por que este PR existe
O commit de documentação foi pushado **depois** que o #103 já havia sido mergeado, então ficou órfão na branch e **não entrou no `main`**. Este PR traz essa documentação para o `main` e ainda corrige uma inconsistência no Swagger.

## Mudanças
**1. Documentação alinhada ao projeto** (commit reaproveitado do #103)
- README: mapa de endpoints completo (+`/usuarios`, `/auth/*`, `/health`) com coluna Auth (—/JWT/Admin)
- requisitos.md: RF-17 (listar usuários), Auth de admin nas rotas de escrita, RNF-02 e contagem de testes (54)
- openapi.yaml: gerado das anotações das rotas (estava vazio) + script `npm run docs`

**2. Correção no Swagger do `POST /afiliados`**
- A rota já exigia admin no código (`authMiddleware + adminMiddleware`), mas a anotação `@openapi` não declarava `security` nem respostas 401/403.
- Agora declara `bearerAuth` + 401 + 403, e o `openapi.yaml` foi regenerado refletindo isso.

## Validação
- `require('./src/app')` carrega sem erro.
- `openapi.yaml` com 10 paths; `POST /afiliados` agora mostra `security: bearerAuth`.
